### PR TITLE
feature: pre-select scopes using URL query params

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,7 +59,6 @@ const App = () => {
     data: {},
   });
 
-  const [scope, setScope] = useState('');
   const [scopes, setScopes] = useState([
     ...localScopes,
     ...urlScopes,
@@ -163,9 +162,6 @@ const App = () => {
    */
   useEffect(() => {
     localStorage.setItem('scope', JSON.stringify(scopes));
-
-    const newScope = Object.keys(scopes).filter((singleScope) => scopes[singleScope]).join(' ');
-    setScope(newScope);
   }, [scopes]);
 
   /**
@@ -232,6 +228,7 @@ const App = () => {
 
     /** we include the clientId and the clientSecret in the
      *  redirect uri to avoid having to store them in the browser */
+    const scope = scopes.join(' ');
     const queryString = `https://accounts.spotify.com/authorize?response_type=code&client_id=${clientId}&scope=${encodeURIComponent(scope)}&redirect_uri=${callbackUri}`;
     window.location.replace(queryString);
   };


### PR DESCRIPTION
## Overview
Adds support to pre-select scopes using `scope` query params.

Also includes a refactor to handle selected scopes as an array, which I found suited the new feature implementation much better. I appreciate that this is quite a loaded change that could have touched things I might not have considered, so I understand if you don't want to accept the refactor part - I've added these changes in separate commits so they can be reverted easily.

## Use-case
I want to be able to link to the [hosted app](https://alecchen.dev/spotify-refresh-token) with some [pre-selected scopes](https://alecchen.dev/spotify-refresh-token?scope=user-top-read&scope=user-library-read), so that the recipient just has to enter their app credentials and follow the Spotify login flow. :slightly_smiling_face:

## Examples
### Single scope
```
http://localhost:5173/spotify-refresh-token/?scope=user-top-read
```

### Multiple scopes
```
http://localhost:5173/spotify-refresh-token/?scope=user-top-read&scope=user-library-read
```

## Considerations
*Update the current URL?*

I thought about whether or not the feature should update the current URL as scopes are selected/deselected, meaning a user could select some scopes, copy the URL and share it with someone else to use the same set. This sort of replaces the local storage mechanism for scope, as the URL would effectively manage that part of the application state. My only reservation here is that if a lot of scopes are selected, the resulting URL will probably be quite long. Maybe this is acceptable, or all specified scopes come from a single query param somehow (e.g. `?scopes=user-top-read%20user-library-read`), or a special case could exist for all scopes being selected (e.g. `?scope=all`)? Something to think about maybe.