### PR TITLE
refactor: scope application state as URL search params

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^18.2.0",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.1",
     "util": "^0.12.4"
   },
   "devDependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -118,11 +118,11 @@ const App = () => {
       setSaveClientCredentials(storedSettings.saveClientCredentials);
     }
 
-    const clientIdStored = localStorage.getItem('clientId');
+    const clientIdStored = localStorage.getItem('clientId') || sessionStorage.getItem('clientId');
     if (clientIdStored) {
       setClientId(clientIdStored);
     }
-    const clientSecretStored = localStorage.getItem('clientSecret');
+    const clientSecretStored = localStorage.getItem('clientSecret') || sessionStorage.getItem('clientSecret');
     if (clientSecretStored) {
       setClientSecret(clientSecretStored);
     }
@@ -134,8 +134,9 @@ const App = () => {
     const sessionScopes = sessionStorage.getItem('scope');
     if (sessionScopes) {
       setScopes(...JSON.parse(sessionScopes));
-      sessionStorage.removeItem('scope');
     }
+
+    sessionStorage.clear();
   }, []);
 
   /**
@@ -244,6 +245,9 @@ const App = () => {
    * Handles the submit button click, which will redirect the user to the Spotify login page
    */
   const handleSubmit = () => {
+    sessionStorage.setItem('clientId', clientId);
+    sessionStorage.setItem('clientSecret', clientSecret);
+
     const selectedScopes = allSelected ? allScopes : scopes;
     sessionStorage.setItem('scope', JSON.stringify(selectedScopes));
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -122,12 +122,6 @@ const App = () => {
     if (refreshTokenStored) {
       setRefreshToken(refreshTokenStored);
     }
-
-    // these needed to be cleared if the user does not want to save them
-    if (storedSettings && !storedSettings.saveClientCredentials) {
-      localStorage.removeItem('clientId');
-      localStorage.removeItem('clientSecret');
-    }
   }, []);
 
   /**
@@ -143,14 +137,6 @@ const App = () => {
       });
     }
   }, [clientId, clientSecret]);
-
-  useEffect(() => {
-    if (saveRefreshToken) {
-      localStorage.setItem('refreshToken', refreshToken);
-    } else {
-      localStorage.removeItem('refreshToken');
-    }
-  }, [saveRefreshToken, refreshToken]);
 
   /**
    * Gets the data from the Spotify API if the access token is set
@@ -192,23 +178,28 @@ const App = () => {
   }, [saveRefreshToken, saveClientCredentials]);
 
   /**
-   * Removes the refresh token from local storage if the user doesn't want to save it
+   * Add or remove the refresh token from local storage
    */
   useEffect(() => {
-    if (!saveRefreshToken) {
+    if (saveRefreshToken) {
+      localStorage.setItem('refreshToken', refreshToken);
+    } else {
       localStorage.removeItem('refreshToken');
     }
-  }, [saveRefreshToken]);
+  }, [saveRefreshToken, refreshToken]);
 
   /**
-   * Removes the client credentials from local storage if the user doesn't want to save them
+   * Add or remove client credentials from local storage
    */
   useEffect(() => {
-    if (!saveClientCredentials) {
+    if (saveClientCredentials) {
+      localStorage.setItem('clientId', clientId);
+      localStorage.setItem('clientSecret', clientSecret);
+    } else {
       localStorage.removeItem('clientId');
       localStorage.removeItem('clientSecret');
     }
-  }, [saveClientCredentials]);
+  }, [saveClientCredentials, clientId, clientSecret]);
 
   /**
    * Handles the scope checkbox change
@@ -241,15 +232,6 @@ const App = () => {
    * Handles the submit button click, which will redirect the user to the Spotify login page
    */
   const handleSubmit = () => {
-    /**
-     * Save the client credentials to local storage,
-     * if the user has decided not to save them, on the next page load they will be cleared
-     * This can be a security risk if the user never comes back to the page, with some error
-     * however, this should not be used for anything other than testing and development
-     */
-    localStorage.setItem('clientId', clientId);
-    localStorage.setItem('clientSecret', clientSecret);
-
     /** we include the clientId and the clientSecret in the
      *  redirect uri to avoid having to store them in the browser */
     const scope = scopes.join(' ');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,10 +57,24 @@ const App = () => {
   const token = searchParams.get('code');
   const scopes = searchParams.getAll('scope');
 
-  const setScopes = (...newScopes) => setSearchParams(newScopes.map(s => ['scope', s]));
+  /**
+   * Set one or more scopes as URL search params in the format `scope=<name>`
+   *
+   * @param {string[]} newScopes
+   */
+  const setScopes = (...newScopes) => setSearchParams(newScopes.map((s) => ['scope', s]));
+
+  /**
+   * Set the all scopes alias URL search param
+   */
   const setAllScopes = () => setSearchParams([['scope', allScopesAlias]]);
 
-  const hasScope = scope => scopes.includes(scope);
+  /**
+   * Check if a scope is present as a URL search param
+   *
+   * @param {string} scope
+   */
+  const hasScope = (scope) => scopes.includes(scope);
 
   // sets the "select all" checkbox to true if all scopes are selected
   const allSelected = hasScope(allScopesAlias);
@@ -197,18 +211,18 @@ const App = () => {
    * Handles the scope checkbox change
    * @param {string} name
    */
-  const handleCheck = name => {
+  const handleCheck = (name) => {
     if (hasScope(name)) {
-      return setScopes(...scopes.filter(s => s !== name));
+      return setScopes(...scopes.filter((s) => s !== name));
     }
 
     if (allSelected) {
-      return setScopes(...allScopes.filter(s => s !== name));
+      return setScopes(...allScopes.filter((s) => s !== name));
     }
 
     const selectedScopes = [...scopes, name];
 
-    if (allScopes.every(s => selectedScopes.includes(s))) {
+    if (allScopes.every((s) => selectedScopes.includes(s))) {
       return setAllScopes();
     }
 
@@ -218,7 +232,7 @@ const App = () => {
   /**
    * handles the "select all" checkbox change
    */
-  const handleSelectAll = () => allSelected ? setScopes() : setAllScopes();
+  const handleSelectAll = () => (allSelected ? setScopes() : setAllScopes());
 
   /**
    * Handles the submit button click, which will redirect the user to the Spotify login page
@@ -311,7 +325,7 @@ const App = () => {
             Scope
           </div>
           <div className="grid gap-2 md:grid-cols-2">
-            {allScopes.map(s => (
+            {allScopes.map((s) => (
               <Checkbox checked={hasScope(s) || allSelected} onClick={() => handleCheck(s)} label={s} />
             ))}
           </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -146,6 +146,10 @@ const App = () => {
       getTokens().then((response) => {
         setAccessToken(response.data.access_token);
         setRefreshToken(response.data.refresh_token);
+        setSearchParams((params) => {
+          params.delete('code');
+          return searchParams;
+        });
       }).catch((error) => {
         console.error(error);
       });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,7 +34,7 @@ const allScopesAlias = 'all';
 let callbackUri = window.location.href.split('/').slice(0, 4).join('/');
 
 // if the callback uri ends with a slash, remove it
-callbackUri = callbackUri.endsWith() === '/' ? callbackUri.slice(0, callbackUri.length - 1) : callbackUri;
+callbackUri = callbackUri.endsWith('/') ? callbackUri.slice(0, callbackUri.length - 1) : callbackUri;
 
 const App = () => {
   const [clientId, setClientId] = useState('');

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,6 +386,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@remix-run/router@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.14.1.tgz#6d2dd03d52e604279c38911afc1079d58c50a755"
+  integrity sha512-Qg4DMQsfPNAs88rb2xkdk03N3bjK4jgX5fR24eHCTR9q6PrhZQZ4UJBPzCHJkIpTRN1UKxx2DzjZmnC+7Lj0Ow==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -2973,6 +2978,21 @@ react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
+
+react-router-dom@^6.21.1:
+  version "6.21.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.21.1.tgz#58b459d2fe1841388c95bb068f85128c45e27349"
+  integrity sha512-QCNrtjtDPwHDO+AO21MJd7yIcr41UetYt5jzaB9Y1UYaPTCnVuJq6S748g1dE11OQlCFIQg+RtAA1SEZIyiBeA==
+  dependencies:
+    "@remix-run/router" "1.14.1"
+    react-router "6.21.1"
+
+react-router@6.21.1:
+  version "6.21.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.21.1.tgz#8db7ee8d7cfc36513c9a66b44e0897208c33be34"
+  integrity sha512-W0l13YlMTm1YrpVIOpjCADJqEUpz1vm+CMo47RuFX4Ftegwm6KOYsL5G3eiE52jnJpKvzm6uB/vTKTPKM8dmkA==
+  dependencies:
+    "@remix-run/router" "1.14.1"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
This idea was [discussed briefly](https://github.com/alecchendev/spotify-refresh-token/pull/6#issuecomment-1606181335) in #6, where the application state for the selected scopes could be stored in the URL as search params. In this change:

- URL updates dynamically when scopes are selected (no window reload on URL change using `react-router-dom`)
- Retains functionality introduced in #6
- Alias scope `all` shown when all scopes are selected for a shorter URL
- Local storage of selected scopes removed entirely (session storage used instead to retain selected scopes on redirect)

Use-cases:
- Some confusing behaviour around the scopes that are pre-selected when navigating to or reloading the web app after #6 was merged (URL search params and local storage selected scopes combining)
- Sharing an all-scopes configuration without a really long URL